### PR TITLE
feature/ECASOGP-8979 to staging

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -6,19 +6,22 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
   <h1 class="usa-sr-only">Federal Committee on Statistical Methodology - Homepage</h1>
   <div class="carousel" id="carousel-1" auto-scroll="8000">
 
-        <section class="carousel-screen usa-graphic-list padding-y-4 carousel-item1" role="img">
+      <section class="carousel-screen usa-graphic-list padding-y-4 carousel-item1" role="img">
             <div class="grid-container">
                 <div class="grid-gap-banner">
-                        <div class="carousel-item__content padding-x-4 padding-y-6 tablet:margin-top-4 tablet:margin-x-0 margin-x-2 usa-prose">
-                            <h2 class="usa-hero__heading">
-                                <span class="text-primary-darker text-bold">Welcome to FCSM.gov</span>
-                            </h2>
-                            <p class="text-gray-70 font-sans-md tablet:font-sans-lg">The Federal Committee on Statistical Methodology (FCSM) is an interagency committee <b>dedicated to improving the quality of Federal statistics.</b></p>
-                            <a class="usa-button usa-button--hover carousel-button" href="{{ site.baseurl }}/about/">View our Mission and Charter</a>
-                        </div>
+                    <div class="carousel-item__content padding-x-4 padding-y-6 tablet:margin-top-4 tablet:margin-x-0 margin-x-2 usa-prose">
+                        <h2 class="usa-hero__heading">
+                            <span class="text-primary-darker text-bold">Welcome to FCSM.gov</span>
+                        </h2>
+                        <p class="text-gray-70 font-sans-md tablet:font-sans-lg">
+                            The Federal Committee on Statistical Methodology (FCSM) is an interagency committee 
+                            <b>dedicated to improving the quality of Federal statistics.</b>
+                        </p>
+                        <a class="usa-button usa-button--hover carousel-button" href="{{ site.baseurl }}/about/" id="mission-button">View our Mission and Charter</a>
+                    </div>
                 </div>
             </div>
-        </section>
+      </section>
 
 
       <section class="carousel-screen usa-graphic-list padding-y-4 carousel-item3" role="img">

--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -148,11 +148,20 @@ circleStore.forEach(circle => {
 })
 })
 
+//Handle Tab feature on initialize carousel button
+let missionButton = document.querySelector('#mission-button');
 
-
-
-
-
+//Handle event in case of tab and focus shifts
+missionButton.addEventListener('keydown', function(event) {
+    if (event.key === 'Tab') {
+        event.preventDefault();
+        if (event.shiftKey) {
+            leftArrow.querySelector('span').focus();
+        } else {
+            rightArrow.querySelector('span').focus();
+        }
+    }
+});
 
 
 


### PR DESCRIPTION
**Feature Preview Link:**  https://federalist-e0a7489d-c5c2-4a41-b4ce-e27bc0bc4913.sites.pages.cloud.gov/preview/gsa/fcsm/feature/ECASOGP-8979


**Description of Jira Story -**

User Story: As A Product Owner I want to 

 

Acceptance Criteria:

Tab order has been corrected
Technical Approach:{}

Ensure tabbing is correctly handled when "Find out more" button is highlighted
Definition of Done:

Tabbing functionality implemented
Subtasks and Points:{}

Assign ECAS-OGP System

What is the overall goal/outcome of this story:

What is the problem that this story is solving:

[L2][FCSM.gov] Carousel - Tab Issue  after "Read More" button in the first slide of the carousel

 Carousel Slides - Tab Order is incorrect

For the Carousel, tab order should first focus on one individual slide and focus on any button or link to the visible slide and then focus to the "Previous slide" arrow button and "next slide" arrow button and then focus to the second slide.

Please refer to this site for the Tab order sequence - https://www.w3.org/WAI/tutorials/carousels/working-example/

Need to be fixed in all FCSM Carousel slides

Note:

This is an issue on FPC and CDO.gov as well for which we have separate defects
[ECASOGP-7994](https://cm-jira.usa.gov/browse/ECASOGP-7994)
[ECASOGP-5319](https://cm-jira.usa.gov/browse/ECASOGP-5319)