### PR TITLE
Staging

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,33 +2,6 @@
   <div class="grid-container usa-footer__return-to-top">
     <a href="#">Return to top</a>
   </div>
-  <div class="usa-footer__primary-section">
-    <nav class="usa-footer__nav" aria-label="Footer navigation">
-      <ul class="grid-row grid-gap">
-        <li class="
-            mobile-lg:grid-col-4
-            desktop:grid-col-auto
-            usa-footer__primary-content
-          ">
-          <a class="usa-footer__primary-link" href="https://www.gsa.gov/website-information/accessibility-aids" >Accessibility</a>
-        </li>
-        <li class="
-            mobile-lg:grid-col-4
-            desktop:grid-col-auto
-            usa-footer__primary-content
-          ">
-          <a class="usa-footer__primary-link" href="https://www.gsa.gov/reference/freedom-of-information-act-foia" >FOIA</a>
-        </li>
-        <li class="
-            mobile-lg:grid-col-4
-            desktop:grid-col-auto
-            usa-footer__primary-content
-          ">
-          <a class="usa-footer__primary-link" href="https://www.gsa.gov/website-information/website-policies" >Privacy Statement</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
   <div class="usa-footer__secondary-section padding-bottom-8">
     <!-- start section -->
     <div class="grid-container">

--- a/groups/cspos.md
+++ b/groups/cspos.md
@@ -25,9 +25,9 @@ languages such a R and Python.</li>
 
 <p>Please contact the group chair(s) if you are a federal employee and interested in participating.</p>
 
+<p><strong><a href="{{site.baseurl}}/assets/files/docs/DSFS_Charter_Signed.pdf">Charter</a></strong></p>
 <p><strong><a href="{{site.baseurl}}/groups/dsfs-resources/">DSFS Resources</a></strong></p>
 <p><strong><a href="{{site.baseurl}}/groups/dsfs-gasp/">Government Advances in Statistical Programming (GASP)</a></strong></p>
-<p><strong><a href="{{site.baseurl}}/assets/files/docs/DSFS_Charter_Signed.pdf">Charter</a></strong></p>
 <p><strong><a href="{{site.baseurl}}/groups/dsfs-presentations/">DSFS Presentations</a></strong></p>
 <p><strong><a href="{{site.baseurl}}/assets/files/docs/GASP-2023-program-with-abstracts-2023-06-13.pdf">GASP 2023 Conference (June 14-15) Agenda</a></strong></p>
 


### PR DESCRIPTION
**Approved by PO**
This looks good. Please proceed.

**[Preview](https://federalist-e0a7489d-c5c2-4a41-b4ce-e27bc0bc4913.sites.pages.cloud.gov/preview/gsa/fcsm/staging/)**

**Request Description**
On FCSM.gov

 As a PO, I want to remove the extra footer at the top - Accessibility, FOIA, and Privacy Statement.

In FCSM , we have Accessibility, FOIA, and Privacy Statement links on both gray color footer and footer identifier session . It is duplicating the links. Please see attached for reference.
![screenshot-1](https://github.com/user-attachments/assets/71c64353-379d-4d42-9d46-4a63ce6a45e9)

<img width="740" alt="FCSM additional header" src="https://github.com/user-attachments/assets/4ac7e5f2-f709-4d1b-a379-9b975aad6e6e">
 
Remove additional footer (we dont need duplicate links in footer)